### PR TITLE
bumping up version of view framework

### DIFF
--- a/hypertrace-view-creator/build.gradle.kts
+++ b/hypertrace-view-creator/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-view-generator-api"))
-  implementation("org.hypertrace.core.viewcreator:view-creator-framework:0.1.6")
+  implementation("org.hypertrace.core.viewcreator:view-creator-framework:0.1.7")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:3.3.3")

--- a/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.test {
 
 dependencies {
   implementation(project(":hypertrace-view-generator-api"))
-  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.5")
+  implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.7")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.2")
 
   implementation("org.hypertrace.traceenricher:enriched-span-constants:0.1.3")


### PR DESCRIPTION
This will incorporate changes to successfully exits on an error which was handled by @tim-mwangi in this PR - https://github.com/hypertrace/view-generator-framework/pull/8