### PR TITLE
Moves to new docker plugin which corrects port defaults and health check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
   id("org.hypertrace.repository-plugin") version "0.2.1"
   id("org.hypertrace.ci-utils-plugin") version "0.1.2"
   id("org.hypertrace.jacoco-report-plugin") version "0.1.1" apply false
-  id("org.hypertrace.docker-java-application-plugin") version "0.4.0" apply false
-  id("org.hypertrace.docker-publish-plugin") version "0.4.0" apply false
+  id("org.hypertrace.docker-java-application-plugin") version "0.5.1" apply false
+  id("org.hypertrace.docker-publish-plugin") version "0.5.1" apply false
 }
 
 subprojects {

--- a/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/build.gradle.kts
@@ -11,6 +11,15 @@ application {
   mainClassName = "org.hypertrace.core.serviceframework.PlatformServiceLauncher"
 }
 
+hypertraceDocker {
+  defaultImage {
+    javaApplication {
+      serviceName.set("all-views")
+      adminPort.set(8099)
+    }
+  }
+}
+
 tasks.test {
   useJUnitPlatform()
 }


### PR DESCRIPTION
after:
```
all-views-creator              java -cp /app/resources:/a ...   Exit 0
all-views-generator            java -cp /app/resources:/a ...   Up (healthy)   8099/tcp
```