### PR TITLE
update pinot broker and server default tags

### DIFF
--- a/hypertrace-view-creator/src/main/resources/configs/backend-entity-view/application.conf
+++ b/hypertrace-view-creator/src/main/resources/configs/backend-entity-view/application.conf
@@ -26,9 +26,9 @@ pinot.loadMode = MMAP
 pinot.numReplicas = 1
 pinot.retentionTimeValue = 5
 pinot.retentionTimeUnit = DAYS
-pinot.brokerTenant = defaultBroker
+pinot.brokerTenant = DefaultTenant
 pinot.brokerTenant = ${?PINOT_BROKER_TAG}
-pinot.serverTenant = defaultServer
+pinot.serverTenant = DefaultTenant
 pinot.serverTenant = ${?PINOT_SERVER_TAG}
 pinot.segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
 

--- a/hypertrace-view-creator/src/main/resources/configs/raw-service-view/application.conf
+++ b/hypertrace-view-creator/src/main/resources/configs/raw-service-view/application.conf
@@ -27,9 +27,9 @@ pinot.loadMode = MMAP
 pinot.numReplicas = 1
 pinot.retentionTimeValue = 5
 pinot.retentionTimeUnit = DAYS
-pinot.brokerTenant = defaultBroker
+pinot.brokerTenant = DefaultTenant
 pinot.brokerTenant = ${?PINOT_BROKER_TAG}
-pinot.serverTenant = defaultServer
+pinot.serverTenant = DefaultTenant
 pinot.serverTenant = ${?PINOT_SERVER_TAG}
 pinot.segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
 

--- a/hypertrace-view-creator/src/main/resources/configs/raw-trace-view/application.conf
+++ b/hypertrace-view-creator/src/main/resources/configs/raw-trace-view/application.conf
@@ -26,9 +26,9 @@ pinot.loadMode = MMAP
 pinot.numReplicas = 1
 pinot.retentionTimeValue = 5
 pinot.retentionTimeUnit = DAYS
-pinot.brokerTenant = defaultBroker
+pinot.brokerTenant = DefaultTenant
 pinot.brokerTenant = ${?PINOT_BROKER_TAG}
-pinot.serverTenant = defaultServer
+pinot.serverTenant = DefaultTenant
 pinot.serverTenant = ${?PINOT_SERVER_TAG}
 pinot.segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
 

--- a/hypertrace-view-creator/src/main/resources/configs/service-call-view/application.conf
+++ b/hypertrace-view-creator/src/main/resources/configs/service-call-view/application.conf
@@ -27,9 +27,9 @@ pinot.loadMode = MMAP
 pinot.numReplicas = 1
 pinot.retentionTimeValue = 5
 pinot.retentionTimeUnit = DAYS
-pinot.brokerTenant = defaultBroker
+pinot.brokerTenant = DefaultTenant
 pinot.brokerTenant = ${?PINOT_BROKER_TAG}
-pinot.serverTenant = defaultServer
+pinot.serverTenant = DefaultTenant
 pinot.serverTenant = ${?PINOT_SERVER_TAG}
 pinot.segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
 

--- a/hypertrace-view-creator/src/main/resources/configs/span-event-view/application.conf
+++ b/hypertrace-view-creator/src/main/resources/configs/span-event-view/application.conf
@@ -26,9 +26,9 @@ pinot.loadMode = MMAP
 pinot.numReplicas = 1
 pinot.retentionTimeValue = 5
 pinot.retentionTimeUnit = DAYS
-pinot.brokerTenant = defaultBroker
+pinot.brokerTenant = DefaultTenant
 pinot.brokerTenant = ${?PINOT_BROKER_TAG}
-pinot.serverTenant = defaultServer
+pinot.serverTenant = DefaultTenant
 pinot.serverTenant = ${?PINOT_SERVER_TAG}
 pinot.segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
 


### PR DESCRIPTION
We have upgraded pinot from version 0.3.0 to 0.5.0. with new version, default tag on pinot server and broker instances has changed to `DefaultTenant`. The pinot tables config is being updated to use new tags.