### PR TITLE
Handle cases where HTTP URL tags do not contain full URL

### DIFF
--- a/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.15")
 
-  implementation("org.hypertrace.traceenricher:enriched-span-constants:0.1.23")
+  implementation("org.hypertrace.traceenricher:enriched-span-constants:0.1.23") // TODO: upgrade its version once the related PR is merged in trace-enricher
   implementation("org.hypertrace.traceenricher:hypertrace-trace-enricher-api:0.1.23")
   implementation("org.hypertrace.core.spannormalizer:raw-span-constants:0.1.22")
   implementation("org.hypertrace.entity.service:entity-service-api:0.1.21")

--- a/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
@@ -290,7 +290,7 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
     switch (protocol) {
       case PROTOCOL_HTTP:
       case PROTOCOL_HTTPS:
-        return EnrichedSpanUtils.getFullHttpUrl(event).orElse(null);
+        return EnrichedSpanUtils.getFullHttpUrl(event).or(() -> EnrichedSpanUtils.getHttpUrl(event)).orElse(null);
       case PROTOCOL_GRPC:
         return event.getEventName();
     }


### PR DESCRIPTION
There can be cases where HTTP URL tags don't contain the full URL. They may only contain the path. E.g. "/customer?customer=392". In such cases, the URL field in Span Event View is set to null and so, the corresponding field in UI is not shown.
In this change, in `SpanEventViewGenerator`, we set the HTTP request URL to the full URL if it is available, else if the tags contain the HTTP URL field(it may be not be a full URL, it may only contain the path), then we set it to that value.