### PR TITLE
disable publish and package charts workflow for consoldiating repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,25 +147,25 @@ workflows:
           context:
             - hypertrace-vulnerability-scanning
             - dockerhub-read
-      - publish:
-          context:
-            - hypertrace-publishing
-            - dockerhub-read
-          requires:
-            - build
-            - validate-charts
-            - snyk-scan
-          filters:
-            branches:
-              only:
-                - main
-      - package-charts:
-          context:
-            - hypertrace-publishing
-            - dockerhub-read
-          requires:
-            - publish
-          filters:
-            branches:
-              only:
-                - main
+#      - publish:
+#          context:
+#            - hypertrace-publishing
+#            - dockerhub-read
+#          requires:
+#            - build
+#            - validate-charts
+#            - snyk-scan
+#          filters:
+#            branches:
+#              only:
+#                - main
+#      - package-charts:
+#          context:
+#            - hypertrace-publishing
+#            - dockerhub-read
+#          requires:
+#            - publish
+#          filters:
+#            branches:
+#              only:
+#                - main


### PR DESCRIPTION
As part of merging all submodules of hypetrace-ingester, we will disable publishing from the individual repo. Just an example PR while we actually plan out merging the below two PRs after final work

hypertrace/hypertrace-ingester#14
hypertrace/hypertrace-ingester#15

issue: hypertrace/hypertrace-ingester#8